### PR TITLE
Added support for function typedefs.

### DIFF
--- a/src/Transpiler.zig
+++ b/src/Transpiler.zig
@@ -1677,7 +1677,7 @@ fn visitFunctionProtoType(self: *Self, name: []const u8, value: *const json.Valu
     try self.out.print("pub const {s} = fn(", .{name});
 
     var return_type_opt: ?*const json.Value = null;
-    var inner_opt = value.object.getPtr("inner");
+    const inner_opt = value.object.getPtr("inner");
     if (inner_opt) |inner| {
         for (inner.array.items, 0..) |*item, i| {
             if (return_type_opt == null) {

--- a/src/main.zig
+++ b/src/main.zig
@@ -27,6 +27,7 @@ pub fn main() !void {
     try clang.append("-Xclang");
     try clang.append("-ast-dump=json");
     try clang.append("-fsyntax-only");
+    try clang.append("-fparse-all-comments");
 
     const argv = try std.process.argsAlloc(allocator);
     defer std.process.argsFree(allocator, argv);


### PR DESCRIPTION
Tested on RecastAssert.h
-fparse-all-comments was needed to make sure all of the comments for it was included in the AST, not sure why.

A bit unsure about needing callconv or not but seems reasonable I guess?